### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -16,7 +16,8 @@ jobs:
       - name: Update apps
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-          Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
+          Invoke-WebRequest -UseBasicParsing get.scoop.sh -OutFile install.ps1
+          .\install.ps1 -RunAsAdmin
 
           function Get-ScoopAppVersions {
               $Versions = @{}


### PR DESCRIPTION
GitHub Actions doesn't seem to have a way to run as an unprivileged user, so I have to force the Scoop installer to run as root for it to actually install.